### PR TITLE
Fix Wrong Upload Location When Sudoing

### DIFF
--- a/JITStreamer/__init__.py
+++ b/JITStreamer/__init__.py
@@ -336,8 +336,7 @@ def upload_file():
             filename = secure_filename(file.filename)
             
             # Define the path to the ~/.pymobiledevice3/ directory
-            user_home = os.path.expanduser('~')
-            upload_folder = os.path.join(user_home, '.pymobiledevice3')
+            upload_folder = common.get_home_folder()
             
             # Create the directory if it doesn't exist
             if not os.path.exists(upload_folder):


### PR DESCRIPTION
As the title says, the folder that
```python
            user_home = os.path.expanduser('~')
            upload_folder = os.path.join(user_home, '.pymobiledevice3')
```
finds may not match the one that `common.get_home_folder()` finds. This may cause pymobiledevice3 failed to find the paring files, especially when sudoing (tested in RPi OS), which is probably one reason for #1.

Change is made in this PR to make the path in accordance with the one in modified pymobiledevice3 (see [here](https://github.com/jawshoeadan/pymobiledevice3/blob/4b3a6314280944dcad7c34ebc6d0af376a84ce91/pymobiledevice3/tunneld.py#L415)).