### PR TITLE
Run JITStreamer in a container

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/macleykun/jitstreamer-2.0:latest
-          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/386,linux/amd64,linux/arm64/v8 #linux/arm/v7,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Convert to lowercase
         id: convert2lowercase
-        run: INPUT=${{ GITHUB_REPOSITORY }}; echo "GITHUB_REPOSITORY_LOWERCASE=${INPUT,,}">>${GITHUB_OUTPUT} 
+        run: INPUT=${{ env.GITHUB_REPOSITORY }}; echo "GITHUB_REPOSITORY_LOWERCASE=${INPUT,,}">>${GITHUB_OUTPUT} 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,4 +29,3 @@ jobs:
           tags: |
             ghcr.io/${{ GITHUB_REPOSITORY@L }}:latest
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
-          

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/macleykun/jitstreamer-2.0:latest
-          platforms: linux/amd64,linux/arm64/v8 #linux/arm/v7,linux/386,
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7,linux/386,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish docker image JITStreamer-2.0
+
+on:
+  push:
+    branches:
+      - 'main'
+#    paths:
+#      - '**.sh'
+#      - 'Dockerfile'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: |
+            ghcr.io/Macleykun/JITStreamer-2.0:latest
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Convert to lowercase
+        id: convert2lowercase
+        run: INPUT=${{ GITHUB_REPOSITORY }}; echo "GITHUB_REPOSITORY_LOWERCASE=${INPUT,,}">>${GITHUB_OUTPUT} 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           push: true
           tags: |
-            ghcr.io/${{ GITHUB_REPOSITORY@L }}:latest
+            ghcr.io/${{steps.convert2lowercase.outputs.GITHUB_REPOSITORY_LOWERCASE}}:latest
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-#          tags: |
-#            ghcr.io/${{ GITHUB_REPOSITORY@L }}:latest
+          tags: |
+            ghcr.io/${{ GITHUB_REPOSITORY@L }}:latest
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
           

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,5 +27,5 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/Macleykun/JITStreamer-2.0:latest
+            ghcr.io/macleykun/jitstreamer-2.0:latest
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,20 +12,24 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: show env vars
+        run: |
+          printenv
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: |
             ghcr.io/Macleykun/JITStreamer-2.0:latest
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
+          

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: show env vars
-        run: |
-          printenv
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -29,7 +26,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: |
-            ghcr.io/Macleykun/JITStreamer-2.0:latest
+#          tags: |
+#            ghcr.io/${{ GITHUB_REPOSITORY@L }}:latest
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
           

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/macleykun/jitstreamer-2.0:latest
-          platforms: linux/386,linux/amd64,linux/arm64/v8 #linux/arm/v7,
+          platforms: linux/amd64,linux/arm64/v8 #linux/arm/v7,linux/386,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,13 +22,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Convert to lowercase
-        id: convert2lowercase
-        run: INPUT=${{ env.GITHUB_REPOSITORY }}; echo "GITHUB_REPOSITORY_LOWERCASE=${INPUT,,}">>${GITHUB_OUTPUT} 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           push: true
           tags: |
-            ghcr.io/${{steps.convert2lowercase.outputs.GITHUB_REPOSITORY_LOWERCASE}}:latest
+            ghcr.io/Macleykun/JITStreamer-2.0:latest
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM python:3-alpine
+FROM python:3-slim-bookworm
 
-RUN apk add gcc git musl-dev openssl-dev linux-headers libffi-dev cargo zlib-dev python3-dev
+RUN git clone https://github.com/stossy11/JITStreamer-2.0.git && \
+    cd JITStreamer-2.0/ && \
+    pip3 install -U -e .
 
-RUN pip3 install -U setuptools pip && git clone https://github.com/Macleykun/JITStreamer-2.0.git && cd JITStreamer-2.0 && pip3 install -U -e .
 # Don't get recommended deps
 # Copy from the source project, not clone it
 # get requirements.txt first, get pip deps and then copy the source to build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-slim
 
-RUN apt-get update && apt-get install cargo rustc git gcc libssl-dev -y && cargo update -p associative-cache@2.0.0 --precise rustc 1.65.0
+RUN apt-get update && apt-get install cargo rustc git gcc libssl-dev -y && cargo update -p associative-cache@2.0.0 --precise rustc 1.65
 
 RUN git clone https://github.com/stossy11/JITStreamer-2.0.git && \
     cd JITStreamer-2.0/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3-alpine
 
 RUN apk add gcc git musl-dev openssl-dev linux-headers libffi-dev cargo #python3-dev
 
-RUN git clone https://github.com/Macleykun/JITStreamer-2.0.git && cd JITStreamer-2.0 && pip3 install -U -e .
+RUN pip3 install -U setuptools pip && git clone https://github.com/Macleykun/JITStreamer-2.0.git && cd JITStreamer-2.0 && pip3 install -U -e .
 # Don't get recommended deps
 # Copy from the source project, not clone it
 # get requirements.txt first, get pip deps and then copy the source to build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3-alpine
 
-RUN apk add gcc git musl-dev openssl-dev
-
+RUN apk add gcc git musl-dev openssl-dev linux-headers #python3-dev
 COPY requirements.txt .
 
 RUN pip3 install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-slim-bookworm
 
-RUN apt-get update && apt-get install cargo git gcc libssl-dev -y
+RUN apt-get update && apt-get install cargo rustc git gcc libssl-dev -y
 
 RUN git clone https://github.com/stossy11/JITStreamer-2.0.git && \
     cd JITStreamer-2.0/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-alpine
 
-RUN apk add gcc git musl-dev openssl-dev linux-headers libffi-dev cargo #python3-dev
+RUN apk add gcc git musl-dev openssl-dev linux-headers libffi-dev cargo zlib-dev #python3-dev
 
 RUN pip3 install -U setuptools pip && git clone https://github.com/Macleykun/JITStreamer-2.0.git && cd JITStreamer-2.0 && pip3 install -U -e .
 # Don't get recommended deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-slim
 
-RUN apt-get update && apt-get install cargo rustc git gcc libssl-dev -y
+RUN apt-get update && apt-get install cargo rustc git gcc libssl-dev -y && cargo update -p associative-cache@2.0.0 --precise rustc 1.65.0
 
 RUN git clone https://github.com/stossy11/JITStreamer-2.0.git && \
     cd JITStreamer-2.0/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM python:3.11-slim-bookworm
-# Get smaller image, preferabbly the alpine 3.11/3
+FROM python:3-alpine
 
-RUN apt update && apt install git gcc libssl-dev -y  && \
-  git clone https://github.com/stossy11/JITStreamer-2.0.git && \
-  cd JITStreamer-2.0/ && \
-  pip3 install -U -e .
+RUN apk add gcc git musl-dev openssl-dev
+
+COPY requirements.txt .
+
+RUN pip3 install -r requirements.txt
+
+COPY . .
+
+RUN pip3 install -U -e .
 # Don't get recommended deps
 # Copy from the source project, not clone it
 # get requirements.txt first, get pip deps and then copy the source to build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM python:3-slim
 
-RUN apt-get update && apt-get install cargo rustc git gcc libssl-dev -y && rustup update stable
+RUN apt-get update && apt-get install cargo rustc git gcc libssl-dev -y
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+
+RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
 
 RUN git clone https://github.com/stossy11/JITStreamer-2.0.git && \
     cd JITStreamer-2.0/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim-bookworm
+FROM python:3-slim
 
 RUN apt-get update && apt-get install cargo rustc git gcc libssl-dev -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-alpine
 
-RUN apk add gcc git musl-dev openssl-dev linux-headers #python3-dev
+RUN apk add gcc git musl-dev openssl-dev linux-headers libffi-dev #python3-dev
 COPY requirements.txt .
 
 RUN pip3 install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-alpine
 
-RUN apk add gcc git musl-dev openssl-dev linux-headers libffi-dev cargo zlib-dev #python3-dev
+RUN apk add gcc git musl-dev openssl-dev linux-headers libffi-dev cargo zlib-dev python3-dev
 
 RUN pip3 install -U setuptools pip && git clone https://github.com/Macleykun/JITStreamer-2.0.git && cd JITStreamer-2.0 && pip3 install -U -e .
 # Don't get recommended deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,8 @@
 FROM python:3-alpine
 
 RUN apk add gcc git musl-dev openssl-dev linux-headers libffi-dev cargo #python3-dev
-COPY requirements.txt .
 
-RUN pip3 install -r requirements.txt
-
-COPY . .
-
-RUN pip3 install -U -e .
+RUN git clone https://github.com/Macleykun/JITStreamer-2.0.git && cd JITStreamer-2.0 && pip3 install -U -e .
 # Don't get recommended deps
 # Copy from the source project, not clone it
 # get requirements.txt first, get pip deps and then copy the source to build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-slim-bookworm
 
-RUN apt-get update && apt-get install Cargo git gcc libssl-dev -y
+RUN apt-get update && apt-get install cargo git gcc libssl-dev -y
 
 RUN git clone https://github.com/stossy11/JITStreamer-2.0.git && \
     cd JITStreamer-2.0/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-slim
 
-RUN apt-get update && apt-get install cargo rustc git gcc libssl-dev -y && cargo update -p associative-cache@2.0.0 --precise rustc 1.65
+RUN apt-get update && apt-get install cargo rustc git gcc libssl-dev -y && rustup update stable
 
 RUN git clone https://github.com/stossy11/JITStreamer-2.0.git && \
     cd JITStreamer-2.0/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-alpine
 
-RUN apk add gcc git musl-dev openssl-dev linux-headers libffi-dev #python3-dev
+RUN apk add gcc git musl-dev openssl-dev linux-headers libffi-dev cargo #python3-dev
 COPY requirements.txt .
 
 RUN pip3 install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3-slim-bookworm
 
+RUN apt-get update && apt-get install git gcc libssl-dev -y
+
 RUN git clone https://github.com/stossy11/JITStreamer-2.0.git && \
     cd JITStreamer-2.0/ && \
     pip3 install -U -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim-bookworm
+# Get smaller image, preferabbly the alpine 3.11/3
+
+RUN apt update && apt install git gcc libssl-dev -y  && \
+  git clone https://github.com/stossy11/JITStreamer-2.0.git && \
+  cd JITStreamer-2.0/ && \
+  pip3 install -U -e .
+# Don't get recommended deps
+# Copy from the source project, not clone it
+# get requirements.txt first, get pip deps and then copy the source to build
+
+CMD ["JITStreamer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-slim-bookworm
 
-RUN apt-get update && apt-get install git gcc libssl-dev -y
+RUN apt-get update && apt-get install Cargo git gcc libssl-dev -y
 
 RUN git clone https://github.com/stossy11/JITStreamer-2.0.git && \
     cd JITStreamer-2.0/ && \

--- a/Dockerfile.alpine-largersomehow
+++ b/Dockerfile.alpine-largersomehow
@@ -1,0 +1,10 @@
+FROM python:3-alpine
+
+RUN apk add gcc git musl-dev openssl-dev linux-headers libffi-dev cargo zlib-dev python3-dev
+
+RUN pip3 install -U setuptools pip && git clone https://github.com/Macleykun/JITStreamer-2.0.git && cd JITStreamer-2.0 && pip3 install -U -e .
+# Don't get recommended deps
+# Copy from the source project, not clone it
+# get requirements.txt first, get pip deps and then copy the source to build
+
+CMD ["JITStreamer"]

--- a/README.md
+++ b/README.md
@@ -86,8 +86,17 @@ Finally run the shortcut again and Enable JIT (the first time may take a while a
 - Stossy11 for this project
 - The rest of the [SideStore](https://sidestore.io) team for encouraging me and the others working to make [pymobiledevice3](https://github.com/doronz88/pymobiledevice3) better
 
+# WIP use Docker to setup JITstreamer
 
+Requirements: have docker
 
+How to run?
+go into the project dir
+docker build . -t testing
+docker run -d --rm -v /var/run:/var/run --device /dev/net/tun --cap-add=NET_ADMIN --cap-add=NET_RAW --network=host testing:latest
+to do the pairing (only once?)
+docker exec -it testing:latest JITStreamer --pair
+docker cp namecontainer:/root/.pymobiledevice3/*.plist . # Copy that boi over to your idevice . Your UDID is in the name btw
 
 
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docker run -d --rm -v /var/run:/var/run --device /dev/net/tun --cap-add=NET_ADMI
 to do the pairing (only once?)
 docker exec -it testing:latest JITStreamer --pair
 docker cp namecontainer:/root/.pymobiledevice3/*.plist . # Copy that boi over to your idevice . Your UDID is in the name btw
-
+safd
 
 
 


### PR DESCRIPTION
WIP
But basically easier and quicker to setup, as installing all those pip deps takes a while (on rpi4). User only needs to run 2-3 commands eventually to get the container running/JITStreamer followed by pairing it and then they need to copy the file to their idevice to enjoy it.

Currently it requires access to the /dev/net/run/ and /dev/run/ dir's to pair and use the tunnelling to get jit working. This also requires setting extra capabilities + host networking. I hope the latter isn't needed but we'll see.

Image currently is 735MB but hope to lower that by optimizing deps and image.
Building is also inefficient as it will (if we use caching in the ci/cd) always get those pip packages even tho the requirements haven't changed.

Lastly, need to setup a CI/CD to host images in github registery, hope to find a way to maybe cache some layer's to avoid rebuilding tha whole thing but i think that's very optional so may not look to much into it.

I haven't tested it like i described in the readme (also needs adjusting ofc). But pretty sure it should work that way as i did so when i run the image directly using bash and invoking jitstreamer that way.